### PR TITLE
Fix unaligned memory access with memcpy

### DIFF
--- a/lib-rt/librt_internal.c
+++ b/lib-rt/librt_internal.c
@@ -3,6 +3,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <stdint.h>
+#include <string.h>
 #include "CPy.h"
 #define LIBRT_INTERNAL_MODULE
 #include "librt_internal.h"
@@ -39,13 +40,14 @@
 
 #define _READ(result, data, type) \
     do { \
-        *(result) = *(type *)(((ReadBufferObject *)data)->ptr); \
+        memcpy((void *) result, ((ReadBufferObject *)data)->ptr, sizeof(type)); \
         ((ReadBufferObject *)data)->ptr += sizeof(type); \
     } while (0)
 
 #define _WRITE(data, type, v) \
     do { \
-       *(type *)(((WriteBufferObject *)data)->ptr) = v; \
+       type temp = v; \
+       memcpy(((WriteBufferObject *)data)->ptr, (const void *) &temp, sizeof(type)); \
        ((WriteBufferObject *)data)->ptr += sizeof(type); \
     } while (0)
 


### PR DESCRIPTION
As the title says.

Tested on amd64 and sparc64 with gcc 15. All unit tests pass.
The compiled code doesn't actually contain a call to memcpy on either architecture, this is optimized away.

Fixes: #26 