### PR TITLE
Only run release step on tags

### DIFF
--- a/.github/workflows/buildwheels.yml
+++ b/.github/workflows/buildwheels.yml
@@ -127,7 +127,7 @@ jobs:
           path: dist/*.tar.gz
 
   release:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' }}
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Just in case to prevent accidentally releasing when manually triggering workflow on a branch.