### PR TITLE
Allow disabling extra flags with LIBRT_NO_EXTRA_FLAGS env variable

### DIFF
--- a/lib-rt/build_setup.py
+++ b/lib-rt/build_setup.py
@@ -36,6 +36,7 @@ EXTRA_FLAGS_PER_COMPILER_TYPE_PER_PATH_COMPONENT = {
 ccompiler.CCompiler.__spawn = ccompiler.CCompiler.spawn  # type: ignore[attr-defined]
 X86_64 = platform.machine() in ("x86_64", "AMD64", "amd64")
 PYODIDE = "PYODIDE" in os.environ
+NO_EXTRA_FLAGS = "LIBRT_NO_EXTRA_FLAGS" in os.environ
 
 
 def spawn(self, cmd, **kwargs) -> None:  # type: ignore[no-untyped-def]
@@ -46,7 +47,7 @@ def spawn(self, cmd, **kwargs) -> None:  # type: ignore[no-untyped-def]
                 continue
             if "base64/arch/" in str(argument):
                 new_cmd.extend(["-msimd128"])
-    else:
+    elif not NO_EXTRA_FLAGS:
         compiler_type: str = self.compiler_type
         extra_options = EXTRA_FLAGS_PER_COMPILER_TYPE_PER_PATH_COMPONENT.get(compiler_type, None)
         new_cmd = list(cmd)


### PR DESCRIPTION
We need a way to disable these when cross compiling as these flags will break due to picking up the host rather than the target.

Should fix:
```
/home/buildroot/buildroot/output/per-package/python-librt/host/bin/aarch64-linux-gcc -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -O2 -g0 -D_FORTIFY_SOURCE=1 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -fPIC -I. -Ibase64 -I/home/buildroot/buildroot/output/build/python3-3.13.11/Include -I/home/buildroot/buildroot/output/build/python3-3.13.11 -c base64/arch/avx/codec.c -o build/temp.linux-aarch64-cpython-313/base64/arch/avx/codec.o -O3 -Wno-unused-function -mavx
aarch64-linux-gcc.br_real: error: unrecognized command-line option ‘-mavx’
error: command '/home/buildroot/buildroot/output/per-package/python-librt/host/bin/aarch64-linux-gcc' failed with exit code 1
```