### PR TITLE
feat: Build wheel for riscv64

### DIFF
--- a/.github/workflows/buildwheels.yml
+++ b/.github/workflows/buildwheels.yml
@@ -30,7 +30,7 @@ jobs:
 
           # For each platform, what arch to use with cibuildwheel:
           platform_archs = {
-              "linux": ["x86_64", "i686", "aarch64"],
+              "linux": ["x86_64", "i686", "aarch64", "riscv64"],
               "macos": ["arm64", "x86_64"],
               "windows": ["x86", "AMD64", "ARM64"],
               "pyodide": ["wasm32"],
@@ -64,7 +64,7 @@ jobs:
                       # For some OS/arch we need to specify OS version
                       if the_os == "windows" and the_arch == "ARM64":
                           them["os-version"] = "11-arm"
-                      if the_arch == "aarch64":
+                      if the_arch == "aarch64" or the_arch == "riscv64":
                           # https://github.com/pypa/cibuildwheel/issues/2257
                           them["os-version"] = "22.04-arm"
                       all_them.append(them)
@@ -91,6 +91,12 @@ jobs:
         shell: bash
         run: |
           cp -r lib-rt/* .
+
+      - name: setup qemu for riscv64
+        uses: docker/setup-qemu-action@v3
+        if: matrix.arch == 'riscv64'
+        with:
+          platforms: riscv64
 
       - uses: pypa/cibuildwheel@v3.2.0
         with:


### PR DESCRIPTION
PyPI recently added support for riscv64 wheel packages, so we can consider adding riscv64 support for librt.

I ran CI on my fork, and here are the [results](https://github.com/ffgan/librt/actions/runs/21385089208).it builds and works fine. So I believe adding riscv64 support to librt will be straightforward.

Feel free to @ me if you have any questions.



---
**Other Info**
Co-authored-by: Jincheng Ni nijincheng@iscas.ac.cn